### PR TITLE
Add comprehensive tests

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,60 @@
+import sys
+import types
+import shutil
+from pathlib import Path
+import importlib.util
+import pytest
+import importlib.metadata
+
+# Ensure package root is importable
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Load numpy stub and insert into sys.modules before project imports
+spec = importlib.util.spec_from_file_location("numpy", Path(__file__).parent / "numpy_stub.py")
+numpy_stub = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(numpy_stub)
+sys.modules.setdefault("numpy", numpy_stub)
+
+# Stub tomlkit using local implementation
+spec_tomlkit = importlib.util.spec_from_file_location("tomlkit", Path(__file__).parent / "tomlkit_stub.py")
+tomlkit_stub = importlib.util.module_from_spec(spec_tomlkit)
+spec_tomlkit.loader.exec_module(tomlkit_stub)
+sys.modules.setdefault("tomlkit", tomlkit_stub)
+
+# Provide a dummy version function for importlib.metadata
+importlib.metadata.version = lambda name: "0.0"
+
+@pytest.fixture(scope="session", autouse=True)
+def prepare_env(tmp_path_factory):
+    # Stub jieba
+    jieba_stub = types.SimpleNamespace(lcut=lambda text: text.split())
+    sys.modules.setdefault("jieba", jieba_stub)
+    # Stub ollama
+    class OllamaResp:
+        def __init__(self, embeddings):
+            self.embeddings = embeddings
+    def embed(model=None, input=None):
+        return OllamaResp([[float(i)] * 3 for i, _ in enumerate(input)])
+    sys.modules.setdefault("ollama", types.SimpleNamespace(embed=embed))
+    # Stub openai
+    class FakeClient:
+        def __init__(self, api_key=None, base_url=None):
+            pass
+        class EmbeddingsEndpoint:
+            def create(self, model=None, input=None):
+                return types.SimpleNamespace(
+                    data=[types.SimpleNamespace(embedding=[float(i)] * 3) for i, _ in enumerate(input)]
+                )
+        @property
+        def embeddings(self):
+            return self.EmbeddingsEndpoint()
+    sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=FakeClient))
+    # Ensure config file exists
+    config_dir = Path.home() / ".texiv"
+    config_dir.mkdir(exist_ok=True)
+    dst = config_dir / "config.toml"
+    example = Path(__file__).resolve().parents[1] / "texiv" / "config" / "example.config.toml"
+    shutil.copy(example, dst)
+    yield
+

--- a/src/tests/numpy_stub.py
+++ b/src/tests/numpy_stub.py
@@ -1,0 +1,105 @@
+import math
+class ndarray:
+    def __init__(self, data):
+        if isinstance(data, ndarray):
+            data = data.data
+        if data and isinstance(data[0], (list, tuple)):
+            self.data=[list(map(float,row)) for row in data]
+            self.ndim=2
+            self.shape=(len(self.data), len(self.data[0]))
+        else:
+            self.data=list(map(float,data))
+            self.ndim=1
+            self.shape=(len(self.data),)
+    def __iter__(self):
+        return iter(self.data)
+    def __len__(self):
+        return len(self.data)
+    def __getitem__(self, idx):
+        return self.data[idx]
+    def _binary(self, other, op):
+        if isinstance(other, ndarray):
+            if self.ndim==2:
+                other_rows = other.data
+                if other.ndim==2 and other.shape[1]==1 and self.shape[1] != 1:
+                    other_rows = [[row[0]] * self.shape[1] for row in other.data]
+                return ndarray([[op(a,b) for a,b in zip(ar, br)] for ar, br in zip(self.data, other_rows)])
+            else:
+                other_vals = other.data
+                if other.ndim==1 and len(other_vals)==1 and len(self.data)!=1:
+                    other_vals = other_vals * len(self.data)
+                return ndarray([op(a,b) for a,b in zip(self.data, other_vals)])
+        else:
+            if self.ndim==2:
+                return ndarray([[op(a,other) for a in ar] for ar in self.data])
+            else:
+                return ndarray([op(a,other) for a in self.data])
+    def __ge__(self, other):
+        return self._binary(other, lambda a,b: a>=b)
+    def __add__(self, other):
+        return self._binary(other, lambda a,b: a+b)
+    def __sub__(self, other):
+        return self._binary(other, lambda a,b: a-b)
+    def __rsub__(self, other):
+        return self._binary(other, lambda a,b: b-a)
+    def __truediv__(self, other):
+        return self._binary(other, lambda a,b: a/b)
+    def __mul__(self, other):
+        return self._binary(other, lambda a,b: a*b)
+    @property
+    def T(self):
+        if self.ndim==2:
+            return ndarray([list(col) for col in zip(*self.data)])
+        else:
+            return self
+
+float64=float
+
+def array(data, dtype=float):
+    return ndarray(data)
+
+def dot(a,b):
+    import builtins
+    a=a.data if isinstance(a, ndarray) else a
+    b=b.data if isinstance(b, ndarray) else b
+    result=[]
+    for row in a:
+        row_res=[]
+        for col in zip(*b):
+            row_res.append(builtins.sum(x*y for x,y in zip(row,col)))
+        result.append(row_res)
+    return ndarray(result)
+
+def _axis_reduce(arr, axis, func):
+    if axis==1:
+        return ndarray([func(row) for row in arr.data])
+    elif axis==0:
+        return ndarray([func(col) for col in zip(*arr.data)])
+    else:
+        if arr.ndim == 1:
+            return func(arr.data)
+        return func([func(row) for row in arr.data])
+
+def any(arr, axis=None):
+    import builtins
+    return _axis_reduce(arr, axis, builtins.any)
+
+def all(arr, axis=None):
+    import builtins
+    return _axis_reduce(arr, axis, builtins.all)
+
+def sum(arr, axis=None):
+    import builtins
+    return _axis_reduce(arr, axis, builtins.sum)
+
+class linalg:
+    @staticmethod
+    def norm(arr, axis=None, keepdims=False):
+        import math, builtins
+        if axis==1:
+            res=[math.sqrt(builtins.sum(x*x for x in row)) for row in arr.data]
+            if keepdims:
+                res=[[v] for v in res]
+            return ndarray(res)
+        else:
+            raise NotImplementedError

--- a/src/tests/test_chunk.py
+++ b/src/tests/test_chunk.py
@@ -1,0 +1,17 @@
+import importlib
+
+
+def test_segment_from_text():
+    chunk_module = importlib.import_module('texiv.core.chunk')
+    chunker = chunk_module.Chunk(stopwords={'我', '天安门'})
+    tokens = chunker.segment_from_text('我 爱 北京 天安门')
+    assert tokens == ['爱', '北京']
+
+
+def test_load_stopwords_file(tmp_path):
+    chunk_module = importlib.import_module('texiv.core.chunk')
+    stop = tmp_path / 'stop.txt'
+    stop.write_text('我')
+    chunker = chunk_module.Chunk()
+    chunker.load_stopwords_file(str(stop))
+    assert chunker.segment_from_text('我 爱 你') == ['爱', '你']

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -1,0 +1,15 @@
+import importlib
+from pathlib import Path
+import shutil
+
+
+def test_set_config(tmp_path, monkeypatch):
+    config_mod = importlib.import_module('texiv.config')
+    cfg_path = tmp_path / 'config.toml'
+    example = Path(__file__).resolve().parents[1] / 'texiv' / 'config' / 'example.config.toml'
+    shutil.copy(example, cfg_path)
+    monkeypatch.setattr(config_mod.Config, 'CONFIG_FILE_PATH', str(cfg_path))
+    cfg = config_mod.Config()
+    monkeypatch.setattr(config_mod.Config, '_write_config_to_disk', lambda self: None)
+    cfg.set_config('embed.ollama.MODEL', 'foo')
+    assert cfg.cfg['embed']['ollama']['MODEL'] == 'foo'

--- a/src/tests/test_embed.py
+++ b/src/tests/test_embed.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_embed_with_ollama():
+    embed_mod = importlib.import_module('texiv.core.embed')
+    emb = embed_mod.Embed(embed_type='ollama', model='m')
+    vec = emb.embed(['a', 'b'])
+    assert vec.shape == (2, 3)
+
+
+def test_embed_with_openai():
+    embed_mod = importlib.import_module('texiv.core.embed')
+    emb = embed_mod.Embed(embed_type='openai', model='m', base_url='x', api_key='y')
+    vec = emb.embed(['x'])
+    assert vec.shape == (1, 3)

--- a/src/tests/test_filter.py
+++ b/src/tests/test_filter.py
@@ -1,0 +1,31 @@
+import importlib
+
+
+def test_filter_value():
+    filt_mod = importlib.import_module('texiv.core.filter')
+    f = filt_mod.Filter(valve=0.5)
+    import numpy as np
+    data = np.array([[0.4, 0.6], [0.8, 0.2]])
+    result = f.filter(data, valve=0.6)
+    assert result.data == [[0.0, 1.0], [1.0, 0.0]]
+
+
+def test_filter_array():
+    filt_mod = importlib.import_module('texiv.core.filter')
+    f = filt_mod.Filter(VALVE_TYPE='array')
+    import numpy as np
+    data = np.array([[0.4, 0.6], [0.7, 0.8]])
+    valve = np.array([[0.5, 0.5], [0.8, 0.6]])
+    result = f.filter(data, valve_array=valve)
+    assert result.data == [[0.0, 1.0], [0.0, 1.0]]
+
+
+def test_two_stage_methods():
+    filt_mod = importlib.import_module('texiv.core.filter')
+    import numpy as np
+    matrix = np.array([[True, False], [True, True], [False, False]])
+    f = filt_mod.Filter()
+    assert f.row_any_true(matrix).data == [1.0, 1.0, 0.0]
+    assert f.row_all_true(matrix).data == [0.0, 1.0, 0.0]
+    maj = f.row_majority_true(np.array([[True, False, False], [True, True, False], [False, False, False]]))
+    assert maj.data == [0.0, 1.0, 0.0]

--- a/src/tests/test_similarity.py
+++ b/src/tests/test_similarity.py
@@ -1,0 +1,11 @@
+import importlib
+
+
+def test_cosine_similarity():
+    sim_mod = importlib.import_module('texiv.core.similarity')
+    sim = sim_mod.Similarity('cosine')
+    import numpy as np
+    a = np.array([[1, 0], [0, 1]])
+    b = np.array([[1, 0], [0, 1]])
+    matrix = sim.similarity(a, b)
+    assert matrix.data == [[1.0, 0.0], [0.0, 1.0]]

--- a/src/tests/test_tiv.py
+++ b/src/tests/test_tiv.py
@@ -1,0 +1,14 @@
+import importlib
+
+
+def test_texiv_it(monkeypatch):
+    texiv_mod = importlib.import_module('texiv.core.texiv')
+    t = texiv_mod.TexIV()
+    monkeypatch.setattr(t.chunker, 'segment_from_text', lambda x: ['a', 'b', 'c'])
+    import numpy as np
+    monkeypatch.setattr(t.embedder, 'embed', lambda inp: np.array([[1], [2], [3]]) if len(inp) > 1 else np.array([[1]]))
+    monkeypatch.setattr(t.similar, 'similarity', lambda a, b: np.array([[0.6], [0.4], [0.8]]))
+    monkeypatch.setattr(t.filter, 'filter', lambda dist: dist >= 0.5)
+    monkeypatch.setattr(t.filter, 'two_stage_filter', lambda m: np.array([row[0] for row in m.data]))
+    res = t.texiv_it('content', ['kw'])
+    assert res == {'freq': 2, 'count': 3, 'rate': 2/3}

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+
+def test_list2nparray():
+    from texiv.core.utils import list2nparray
+    data = [[1, 2], [3, 4]]
+    arr = list2nparray(data)
+    assert arr.shape == (2, 2)
+    assert arr.data == [[1.0, 2.0], [3.0, 4.0]]

--- a/src/tests/tomlkit_stub.py
+++ b/src/tests/tomlkit_stub.py
@@ -1,0 +1,22 @@
+import tomllib
+
+def parse(s):
+    return tomllib.loads(s)
+
+def dumps(data):
+    lines = []
+    for key, value in data.items():
+        if isinstance(value, dict):
+            lines.append(f"[{key}]")
+            for k2, v2 in value.items():
+                if isinstance(v2, str):
+                    lines.append(f"{k2} = \"{v2}\"")
+                else:
+                    lines.append(f"{k2} = {v2}")
+            lines.append("")
+        else:
+            if isinstance(value, str):
+                lines.append(f"{key} = \"{value}\"")
+            else:
+                lines.append(f"{key} = {value}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- implement pytest environment bootstrap via conftest
- add numpy and tomlkit stubs for tests
- create detailed tests for utils, chunk, config, embed, filter, similarity and TexIV

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618a194fbc8320a6f673d0d2432556